### PR TITLE
More resilient FilterOutCommonParams for Help.tests.ps1 

### DIFF
--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -4,9 +4,10 @@ BeforeDiscovery {
 
     function global:FilterOutCommonParams {
         param ($Params)
-        $commonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters +
-        [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
-        $params | Where-Object { $_.Name -notin $commonParameters } | Sort-Object -Property Name -Unique
+        if (-not $script:CommonParameterKeys) {
+            $script:CommonParameterKeys = ([System.Management.Automation.PSCmdlet]::CommonParameters + [System.Management.Automation.PSCmdlet]::OptionalCommonParameters).Keys
+        }
+        $params | Where-Object { $_.Name -notin $script:CommonParameterKeys } | Sort-Object -Property Name -Unique
     }
 
     $manifest             = Import-PowerShellDataFile -Path $env:BHPSModuleManifest

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -4,12 +4,9 @@ BeforeDiscovery {
 
     function global:FilterOutCommonParams {
         param ($Params)
-        $commonParams = @(
-            'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
-            'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction',
-            'WarningVariable', 'Confirm', 'Whatif'
-        )
-        $params | Where-Object { $_.Name -notin $commonParams } | Sort-Object -Property Name -Unique
+        $commonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters +
+        [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+        $params | Where-Object { $_.Name -notin $commonParameters } | Sort-Object -Property Name -Unique
     }
 
     $manifest             = Import-PowerShellDataFile -Path $env:BHPSModuleManifest


### PR DESCRIPTION
## Description
This makes the common parameters more resilient over time.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
