### PR TITLE
Replace all the tabs so first runs pass

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,29 +1,29 @@
 {
-	"name": "PowerShell",
-	"dockerFile": "Dockerfile",
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"terminal.integrated.profiles.linux": {
-					"bash": {
-						"path": "usr/bin/bash",
-						"icon": "terminal-bash"
-					},
-					"zsh": {
-						"path": "usr/bin/zsh"
-					},
-					"pwsh": {
-						"path": "/usr/bin/pwsh",
-						"icon": "terminal-powershell"
-					}
-				},
-				"terminal.integrated.defaultProfile.linux": "pwsh"
-			},
-			"extensions": ["ms-vscode.powershell", "davidanson.vscode-markdownlint"]
-		}
-	},
-	"postCreateCommand": "pwsh -c './build.ps1 -Task Init -Bootstrap'",
-	"mounts": [
-		"source=${localEnv:USERPROFILE}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
-	]
+    "name": "PowerShell",
+    "dockerFile": "Dockerfile",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "usr/bin/bash",
+                        "icon": "terminal-bash"
+                    },
+                    "zsh": {
+                        "path": "usr/bin/zsh"
+                    },
+                    "pwsh": {
+                        "path": "/usr/bin/pwsh",
+                        "icon": "terminal-powershell"
+                    }
+                },
+                "terminal.integrated.defaultProfile.linux": "pwsh"
+            },
+            "extensions": ["ms-vscode.powershell", "davidanson.vscode-markdownlint"]
+        }
+    },
+    "postCreateCommand": "pwsh -c './build.ps1 -Task Init -Bootstrap'",
+    "mounts": [
+        "source=${localEnv:USERPROFILE}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+    ]
 }

--- a/PSStucco/plasterManifest.xml
+++ b/PSStucco/plasterManifest.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <plasterManifest
   schemaVersion="1.1"
   templateType="Project" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">

--- a/PSStucco/template/_devcontainer/devcontainer.json
+++ b/PSStucco/template/_devcontainer/devcontainer.json
@@ -1,26 +1,26 @@
 {
-	"name": "PowerShell",
-	"dockerFile": "Dockerfile",
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"terminal.integrated.profiles.linux": {
-					"bash": {
-						"path": "usr/bin/bash",
-						"icon": "terminal-bash"
-					},
-					"zsh": {
-						"path": "usr/bin/zsh"
-					},
-					"pwsh": {
-						"path": "/usr/bin/pwsh",
-						"icon": "terminal-powershell"
-					}
-				},
-				"terminal.integrated.defaultProfile.linux": "pwsh"
-			},
-			"extensions": ["ms-vscode.powershell", "davidanson.vscode-markdownlint"]
-		}
-	},
-	"postCreateCommand": "pwsh -c './build.ps1 -Task Init -Bootstrap'"
+    "name": "PowerShell",
+    "dockerFile": "Dockerfile",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "usr/bin/bash",
+                        "icon": "terminal-bash"
+                    },
+                    "zsh": {
+                        "path": "usr/bin/zsh"
+                    },
+                    "pwsh": {
+                        "path": "/usr/bin/pwsh",
+                        "icon": "terminal-powershell"
+                    }
+                },
+                "terminal.integrated.defaultProfile.linux": "pwsh"
+            },
+            "extensions": ["ms-vscode.powershell", "davidanson.vscode-markdownlint"]
+        }
+    },
+    "postCreateCommand": "pwsh -c './build.ps1 -Task Init -Bootstrap'"
 }


### PR DESCRIPTION
Currently when you deploy a new instance of this template the build fails because there are files with tabs.
This is the output of running the suggested command:
```powershell
> Import-Module .\tests\MetaFixers.psm1
> Get-TextFilesList $pwd | ConvertTo-SpaceIndentation
```